### PR TITLE
chore: sort packages alphabetically, fix tabsheet 

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "@vaadin/text-area": "24.0.0-alpha1",
     "@vaadin/text-field": "24.0.0-alpha1",
     "@vaadin/time-picker": "24.0.0-alpha1",
+    "@vaadin/tooltip": "24.0.0-alpha1",
     "@vaadin/upload": "24.0.0-alpha1",
     "@vaadin/vaadin-development-mode-detector": "^2.0.0",
     "@vaadin/vaadin-list-mixin": "24.0.0-alpha1",
@@ -123,8 +124,7 @@
     "tslib": "*",
     "typescript": "^4.5.5",
     "webpack": "^5.68.0",
-    "webpack-cli": "^4.9.2",
-    "@vaadin/tooltip": "24.0.0-alpha1"
+    "webpack-cli": "^4.9.2"
   },
   "peerDependencies": {
     "@polymer/iron-flex-layout": "3.0.1",
@@ -184,6 +184,7 @@
     "@vaadin/select": "24.0.0-alpha1",
     "@vaadin/split-layout": "24.0.0-alpha1",
     "@vaadin/tabs": "24.0.0-alpha1",
+    "@vaadin/tabsheet": "24.0.0-alpha1",
     "@vaadin/text-area": "24.0.0-alpha1",
     "@vaadin/text-field": "24.0.0-alpha1",
     "@vaadin/time-picker": "24.0.0-alpha1",
@@ -202,8 +203,7 @@
     "lit": "2.3.0",
     "ol": "6.13.0",
     "quickselect": "2.0.0",
-    "rbush": "3.0.1",
-    "@vaadin/tabsheet": "24.0.0-alpha1"
+    "rbush": "3.0.1"
   },
   "peerDependenciesMeta": {
     "@polymer/iron-flex-layout": {
@@ -375,6 +375,9 @@
       "optional": true
     },
     "@vaadin/tabs": {
+      "optional": true
+    },
+    "@vaadin/tabsheet": {
       "optional": true
     },
     "@vaadin/text-area": {


### PR DESCRIPTION
## Description

Changed to sort packages, also added missing `peerDependenciesMeta` for `@vaadin/tabsheet`.

## Type of change

- Internal change