### PR TITLE
chore: add missing multi-select-combo-box (V23.2)

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -68,6 +68,7 @@ export const vaadinWebComponentPackages = [
   '@vaadin/menu-bar',
   '@vaadin/message-input',
   '@vaadin/message-list',
+  '@vaadin/multi-select-combo-box',
   '@vaadin/notification',
   '@vaadin/number-field',
   '@vaadin/password-field',

--- a/build.config.ts
+++ b/build.config.ts
@@ -84,7 +84,6 @@ export const vaadinWebComponentPackages = [
   '@vaadin/text-field',
   '@vaadin/time-picker',
   '@vaadin/upload',
-  '@vaadin/vaadin-context-menu',
   '@vaadin/vaadin-lumo-styles',
   '@vaadin/vaadin-list-mixin',
   '@vaadin/vaadin-overlay',

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "@vaadin/menu-bar": "23.2.6",
         "@vaadin/message-input": "23.2.6",
         "@vaadin/message-list": "23.2.6",
+        "@vaadin/multi-select-combo-box": "23.2.6",
         "@vaadin/notification": "23.2.6",
         "@vaadin/number-field": "23.2.6",
         "@vaadin/password-field": "23.2.6",
@@ -143,6 +144,7 @@
         "@vaadin/menu-bar": "23.2.6",
         "@vaadin/message-input": "23.2.6",
         "@vaadin/message-list": "23.2.6",
+        "@vaadin/multi-select-combo-box": "23.2.6",
         "@vaadin/notification": "23.2.6",
         "@vaadin/number-field": "23.2.6",
         "@vaadin/password-field": "23.2.6",
@@ -158,7 +160,6 @@
         "@vaadin/text-field": "23.2.6",
         "@vaadin/time-picker": "23.2.6",
         "@vaadin/upload": "23.2.6",
-        "@vaadin/vaadin-context-menu": "23.2.6",
         "@vaadin/vaadin-development-mode-detector": "2.0.5",
         "@vaadin/vaadin-list-mixin": "23.2.6",
         "@vaadin/vaadin-lumo-styles": "23.2.6",
@@ -309,6 +310,9 @@
           "optional": true
         },
         "@vaadin/message-list": {
+          "optional": true
+        },
+        "@vaadin/multi-select-combo-box": {
           "optional": true
         },
         "@vaadin/notification": {
@@ -1378,6 +1382,23 @@
         "@polymer/polymer": "^3.0.0",
         "@vaadin/avatar": "~23.2.6",
         "@vaadin/component-base": "~23.2.6",
+        "@vaadin/vaadin-lumo-styles": "~23.2.6",
+        "@vaadin/vaadin-material-styles": "~23.2.6",
+        "@vaadin/vaadin-themable-mixin": "~23.2.6"
+      }
+    },
+    "node_modules/@vaadin/multi-select-combo-box": {
+      "version": "23.2.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/multi-select-combo-box/-/multi-select-combo-box-23.2.6.tgz",
+      "integrity": "sha512-dutpLop6pRfaZ7kexVNC9n+8e53puP3lVGDn3EMMclGVMsxUYNwPvIMkFmjGD3lb6EUcSYkclJB1hcEisPLz3w==",
+      "dev": true,
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/combo-box": "~23.2.6",
+        "@vaadin/component-base": "~23.2.6",
+        "@vaadin/field-base": "~23.2.6",
+        "@vaadin/input-container": "~23.2.6",
+        "@vaadin/lit-renderer": "~23.2.6",
         "@vaadin/vaadin-lumo-styles": "~23.2.6",
         "@vaadin/vaadin-material-styles": "~23.2.6",
         "@vaadin/vaadin-themable-mixin": "~23.2.6"
@@ -5211,6 +5232,23 @@
         "@polymer/polymer": "^3.0.0",
         "@vaadin/avatar": "~23.2.6",
         "@vaadin/component-base": "~23.2.6",
+        "@vaadin/vaadin-lumo-styles": "~23.2.6",
+        "@vaadin/vaadin-material-styles": "~23.2.6",
+        "@vaadin/vaadin-themable-mixin": "~23.2.6"
+      }
+    },
+    "@vaadin/multi-select-combo-box": {
+      "version": "23.2.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/multi-select-combo-box/-/multi-select-combo-box-23.2.6.tgz",
+      "integrity": "sha512-dutpLop6pRfaZ7kexVNC9n+8e53puP3lVGDn3EMMclGVMsxUYNwPvIMkFmjGD3lb6EUcSYkclJB1hcEisPLz3w==",
+      "dev": true,
+      "requires": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/combo-box": "~23.2.6",
+        "@vaadin/component-base": "~23.2.6",
+        "@vaadin/field-base": "~23.2.6",
+        "@vaadin/input-container": "~23.2.6",
+        "@vaadin/lit-renderer": "~23.2.6",
         "@vaadin/vaadin-lumo-styles": "~23.2.6",
         "@vaadin/vaadin-material-styles": "~23.2.6",
         "@vaadin/vaadin-themable-mixin": "~23.2.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
         "@vaadin/text-field": "23.2.6",
         "@vaadin/time-picker": "23.2.6",
         "@vaadin/upload": "23.2.6",
-        "@vaadin/vaadin-context-menu": "23.2.6",
         "@vaadin/vaadin-development-mode-detector": "^2.0.0",
         "@vaadin/vaadin-list-mixin": "23.2.6",
         "@vaadin/vaadin-lumo-styles": "23.2.6",
@@ -1623,15 +1622,6 @@
         "@vaadin/vaadin-lumo-styles": "~23.2.6",
         "@vaadin/vaadin-material-styles": "~23.2.6",
         "@vaadin/vaadin-themable-mixin": "~23.2.6"
-      }
-    },
-    "node_modules/@vaadin/vaadin-context-menu": {
-      "version": "23.2.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-context-menu/-/vaadin-context-menu-23.2.6.tgz",
-      "integrity": "sha512-pOiAEMSK/lHeJqzJ3qo+XwoosjWhnZCVHkAO9moFfmiEuyLwDAZKF7EowWpRYtQ2hGpVAP4nSCNxEAFCovdmZg==",
-      "dev": true,
-      "dependencies": {
-        "@vaadin/context-menu": "~23.2.6"
       }
     },
     "node_modules/@vaadin/vaadin-development-mode-detector": {
@@ -5473,15 +5463,6 @@
         "@vaadin/vaadin-lumo-styles": "~23.2.6",
         "@vaadin/vaadin-material-styles": "~23.2.6",
         "@vaadin/vaadin-themable-mixin": "~23.2.6"
-      }
-    },
-    "@vaadin/vaadin-context-menu": {
-      "version": "23.2.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-context-menu/-/vaadin-context-menu-23.2.6.tgz",
-      "integrity": "sha512-pOiAEMSK/lHeJqzJ3qo+XwoosjWhnZCVHkAO9moFfmiEuyLwDAZKF7EowWpRYtQ2hGpVAP4nSCNxEAFCovdmZg==",
-      "dev": true,
-      "requires": {
-        "@vaadin/context-menu": "~23.2.6"
       }
     },
     "@vaadin/vaadin-development-mode-detector": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "webpack": "^5.68.0",
     "webpack-cli": "^4.9.2",
     "@vaadin/lit-renderer": "23.2.6",
-    "@vaadin/vaadin-context-menu": "23.2.6",
     "@vaadin/vaadin-overlay": "23.2.6"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@vaadin/menu-bar": "23.2.6",
     "@vaadin/message-input": "23.2.6",
     "@vaadin/message-list": "23.2.6",
+    "@vaadin/multi-select-combo-box": "23.2.6",
     "@vaadin/notification": "23.2.6",
     "@vaadin/number-field": "23.2.6",
     "@vaadin/password-field": "23.2.6",
@@ -171,6 +172,7 @@
     "@vaadin/menu-bar": "23.2.6",
     "@vaadin/message-input": "23.2.6",
     "@vaadin/message-list": "23.2.6",
+    "@vaadin/multi-select-combo-box": "23.2.6",
     "@vaadin/notification": "23.2.6",
     "@vaadin/number-field": "23.2.6",
     "@vaadin/password-field": "23.2.6",
@@ -200,8 +202,7 @@
     "lit": "2.3.0",
     "ol": "6.13.0",
     "quickselect": "2.0.0",
-    "rbush": "3.0.1",
-    "@vaadin/vaadin-context-menu": "23.2.6"
+    "rbush": "3.0.1"
   },
   "peerDependenciesMeta": {
     "@polymer/iron-flex-layout": {
@@ -337,6 +338,9 @@
       "optional": true
     },
     "@vaadin/message-list": {
+      "optional": true
+    },
+    "@vaadin/multi-select-combo-box": {
       "optional": true
     },
     "@vaadin/notification": {

--- a/src/all-imports.js
+++ b/src/all-imports.js
@@ -42,6 +42,8 @@ import '@vaadin/login/vaadin-login-form.js';
 import '@vaadin/menu-bar';
 import '@vaadin/message-input';
 import '@vaadin/message-list';
+import '@vaadin/multi-select-combo-box';
+import '@vaadin/multi-select-combo-box/lit.js';
 import '@vaadin/notification';
 import '@vaadin/notification/lit.js';
 import '@vaadin/number-field';

--- a/src/all-imports.js
+++ b/src/all-imports.js
@@ -87,7 +87,6 @@ import '@vaadin/vaadin-development-mode-detector';
 import '@vaadin/vaadin-usage-statistics';
 // FIXME: make components not depend on those
 // ignore deprecated import '@vaadin/vaadin-overlay';
-// ignore deprecated import '@vaadin/vaadin-context-menu';
 /* External dependencies */
 // ignore non-resolvable import '@polymer/iron-flex-layout';
 import '@polymer/iron-icon';


### PR DESCRIPTION
## Description

1. Added missing `@vaadin/multi-select-combo-box` package to `23.2` branch for Vaadin 23.2,
2. Removed no longer needed `@vaadin/vaadin-context-menu` - see [the web components fix](https://github.com/vaadin/web-components/pull/4116).

## Type of change

- Internal change