### PR TITLE
chore: remove iron-icon and iron-iconset-svg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,6 @@
       "license": "(Apache-2.0 OR SEE LICENSE IN https://vaadin.com/license/cvdl-4.0)",
       "devDependencies": {
         "@lit/reactive-element": "./src/fake-modules/@lit/reactive-element",
-        "@polymer/iron-icon": "3.0.1",
-        "@polymer/iron-iconset-svg": "3.0.1",
-        "@polymer/iron-media-query": "3.0.1",
-        "@polymer/iron-meta": "3.0.1",
         "@polymer/polymer": "3.5.1",
         "@rollup/plugin-node-resolve": "^13.1.3",
         "@rollup/plugin-typescript": "^8.3.0",
@@ -100,11 +96,6 @@
         "webpack-cli": "^4.9.2"
       },
       "peerDependencies": {
-        "@polymer/iron-flex-layout": "3.0.1",
-        "@polymer/iron-icon": "3.0.1",
-        "@polymer/iron-iconset-svg": "3.0.1",
-        "@polymer/iron-media-query": "3.0.1",
-        "@polymer/iron-meta": "3.0.1",
         "@polymer/polymer": "3.5.1",
         "@vaadin/accordion": "24.0.0-alpha1",
         "@vaadin/app-layout": "24.0.0-alpha1",
@@ -180,21 +171,6 @@
         "rbush": "3.0.1"
       },
       "peerDependenciesMeta": {
-        "@polymer/iron-flex-layout": {
-          "optional": true
-        },
-        "@polymer/iron-icon": {
-          "optional": true
-        },
-        "@polymer/iron-iconset-svg": {
-          "optional": true
-        },
-        "@polymer/iron-media-query": {
-          "optional": true
-        },
-        "@polymer/iron-meta": {
-          "optional": true
-        },
         "@polymer/polymer": {
           "optional": true
         },
@@ -558,7 +534,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.1.tgz",
       "integrity": "sha512-7gB869czArF+HZcPTVSgvA7tXYFze9EKckvM95NB7SqYF+NnsQyhoXgKnpFwGyo95lUjUW9TFDLUwDXnCYFtkw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -584,15 +560,6 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
-    "node_modules/@polymer/iron-media-query": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-media-query/-/iron-media-query-3.0.1.tgz",
-      "integrity": "sha512-czUX1pm1zfmfcZtq5J57XFkcobBv08Y50exp0/3v8Bos5VL/jv2tU0RwiTfDBxUMhjicGbgwEBFQPY2V5DMzyw==",
-      "dev": true,
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
     "node_modules/@polymer/iron-meta": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/iron-meta/-/iron-meta-3.0.1.tgz",
@@ -606,7 +573,7 @@
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.5.1.tgz",
       "integrity": "sha512-JlAHuy+1qIC6hL1ojEUfIVD58fzTpJAoCxFwV5yr0mYTXV1H8bz5zy0+rC963Cgr9iNXQ4T9ncSjC2fkF9BQfw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@webcomponents/shadycss": "^1.9.1"
       }
@@ -4474,7 +4441,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.1.tgz",
       "integrity": "sha512-7gB869czArF+HZcPTVSgvA7tXYFze9EKckvM95NB7SqYF+NnsQyhoXgKnpFwGyo95lUjUW9TFDLUwDXnCYFtkw==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -4500,15 +4467,6 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
-    "@polymer/iron-media-query": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-media-query/-/iron-media-query-3.0.1.tgz",
-      "integrity": "sha512-czUX1pm1zfmfcZtq5J57XFkcobBv08Y50exp0/3v8Bos5VL/jv2tU0RwiTfDBxUMhjicGbgwEBFQPY2V5DMzyw==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
     "@polymer/iron-meta": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/iron-meta/-/iron-meta-3.0.1.tgz",
@@ -4522,7 +4480,7 @@
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.5.1.tgz",
       "integrity": "sha512-JlAHuy+1qIC6hL1ojEUfIVD58fzTpJAoCxFwV5yr0mYTXV1H8bz5zy0+rC963Cgr9iNXQ4T9ncSjC2fkF9BQfw==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@webcomponents/shadycss": "^1.9.1"
       }

--- a/package.json
+++ b/package.json
@@ -38,10 +38,6 @@
   "homepage": "https://github.com/vaadin/platform#readme",
   "devDependencies": {
     "@lit/reactive-element": "./src/fake-modules/@lit/reactive-element",
-    "@polymer/iron-icon": "3.0.1",
-    "@polymer/iron-iconset-svg": "3.0.1",
-    "@polymer/iron-media-query": "3.0.1",
-    "@polymer/iron-meta": "3.0.1",
     "@polymer/polymer": "3.5.1",
     "@rollup/plugin-node-resolve": "^13.1.3",
     "@rollup/plugin-typescript": "^8.3.0",
@@ -128,11 +124,6 @@
     "webpack-cli": "^4.9.2"
   },
   "peerDependencies": {
-    "@polymer/iron-flex-layout": "3.0.1",
-    "@polymer/iron-icon": "3.0.1",
-    "@polymer/iron-iconset-svg": "3.0.1",
-    "@polymer/iron-media-query": "3.0.1",
-    "@polymer/iron-meta": "3.0.1",
     "@polymer/polymer": "3.5.1",
     "@vaadin/accordion": "24.0.0-alpha1",
     "@vaadin/app-layout": "24.0.0-alpha1",
@@ -199,7 +190,6 @@
     "@vaadin/vaadin-usage-statistics": "2.1.2",
     "@vaadin/vertical-layout": "24.0.0-alpha1",
     "@vaadin/virtual-list": "24.0.0-alpha1",
-    "@webcomponents/shadycss": "1.11.0",
     "cookieconsent": "3.1.1",
     "highcharts": "9.2.2",
     "lit": "2.3.0",
@@ -208,21 +198,6 @@
     "rbush": "3.0.1"
   },
   "peerDependenciesMeta": {
-    "@polymer/iron-flex-layout": {
-      "optional": true
-    },
-    "@polymer/iron-icon": {
-      "optional": true
-    },
-    "@polymer/iron-iconset-svg": {
-      "optional": true
-    },
-    "@polymer/iron-media-query": {
-      "optional": true
-    },
-    "@polymer/iron-meta": {
-      "optional": true
-    },
     "@polymer/polymer": {
       "optional": true
     },
@@ -419,9 +394,6 @@
       "optional": true
     },
     "@vaadin/virtual-list": {
-      "optional": true
-    },
-    "@webcomponents/shadycss": {
       "optional": true
     },
     "cookieconsent": {

--- a/src/all-imports.js
+++ b/src/all-imports.js
@@ -89,11 +89,6 @@ import '@vaadin/vaadin-themable-mixin';
 import '@vaadin/vaadin-development-mode-detector';
 import '@vaadin/vaadin-usage-statistics';
 /* External dependencies */
-// ignore non-resolvable import '@polymer/iron-flex-layout';
-import '@polymer/iron-icon';
-import '@polymer/iron-iconset-svg';
-import '@polymer/iron-media-query';
-import '@polymer/iron-meta';
 import '@polymer/polymer';
 // ignore non-resolvable import '@webcomponents/shadycss';
 import 'cookieconsent';


### PR DESCRIPTION
## Description

1. Removed no longer used `iron-icon` and `iron-iconset-svg` which will be removed in WC 24.0.0-alpha2,
2. Removed `iron-meta` and `iron-flex-layout` as these are transitive dependencies of those components,
3. Removed `iron-media-query` which is no longer used by any of our web components (already in V23.2).

See also:

- https://github.com/vaadin/web-components/pull/4878
- https://github.com/vaadin/web-components/pull/4879

## Type of change

- Internal change