### PR TITLE
Remove the import for side-nav/enable.js

### DIFF
--- a/src/all-imports.js
+++ b/src/all-imports.js
@@ -56,7 +56,6 @@ import '@vaadin/scroller';
 import '@vaadin/select';
 import '@vaadin/select/lit.js';
 import '@vaadin/side-nav';
-import '@vaadin/side-nav/enable.js';
 import '@vaadin/side-nav/vaadin-side-nav-item.js';
 import '@vaadin/split-layout';
 import '@vaadin/tabs';


### PR DESCRIPTION
this has been removed from web component since 24.2.0-alpha11
https://github.com/vaadin/web-components/commit/24037c38d78d7ac82a8cc56ba53974ce4a99e092