### PR TITLE
chore: update dedupe-mixin version to 1.4.0 (24.4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "webpack-cli": "^4.9.2"
       },
       "peerDependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@open-wc/dedupe-mixin": "1.4.0",
         "@polymer/polymer": "3.5.1",
         "@vaadin/a11y-base": "24.4.1",
         "@vaadin/accordion": "24.4.1",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@vaadin/a11y-base": "24.4.1"
   },
   "peerDependencies": {
-    "@open-wc/dedupe-mixin": "^1.3.0",
+    "@open-wc/dedupe-mixin": "1.4.0",
     "@polymer/polymer": "3.5.1",
     "@vaadin/a11y-base": "24.4.1",
     "@vaadin/accordion": "24.4.1",


### PR DESCRIPTION
## Description

Let's use the latest version of this dependency.

## Type of change

- Version update