### PR TITLE
chore: bump usage statistics to v2.1.3 (#134) (CP: 24.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -163,7 +163,7 @@
         "@vaadin/vaadin-development-mode-detector": "2.0.7",
         "@vaadin/vaadin-lumo-styles": "24.3.20",
         "@vaadin/vaadin-themable-mixin": "24.3.20",
-        "@vaadin/vaadin-usage-statistics": "2.1.2",
+        "@vaadin/vaadin-usage-statistics": "2.1.3",
         "@vaadin/vertical-layout": "24.3.20",
         "@vaadin/virtual-list": "24.3.20",
         "cookieconsent": "3.1.1",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@vaadin/vaadin-usage-statistics": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.2.tgz",
-      "integrity": "sha512-xKs1PvRfTXsG0eWWcImLXWjv7D+f1vfoIvovppv6pZ5QX8xgcxWUdNgERlOOdGt3CTuxQXukTBW3+Qfva+OXSg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.3.tgz",
+      "integrity": "sha512-8r4TNknD7OJQADe3VygeofFR7UNAXZ2/jjBFP5dgI8+2uMfnuGYgbuHivasKr9WSQ64sPej6m8rDoM1uSllXjQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -5709,9 +5709,9 @@
       }
     },
     "@vaadin/vaadin-usage-statistics": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.2.tgz",
-      "integrity": "sha512-xKs1PvRfTXsG0eWWcImLXWjv7D+f1vfoIvovppv6pZ5QX8xgcxWUdNgERlOOdGt3CTuxQXukTBW3+Qfva+OXSg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.3.tgz",
+      "integrity": "sha512-8r4TNknD7OJQADe3VygeofFR7UNAXZ2/jjBFP5dgI8+2uMfnuGYgbuHivasKr9WSQ64sPej6m8rDoM1uSllXjQ==",
       "dev": true,
       "requires": {
         "@vaadin/vaadin-development-mode-detector": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "@vaadin/vaadin-development-mode-detector": "2.0.7",
     "@vaadin/vaadin-lumo-styles": "24.3.20",
     "@vaadin/vaadin-themable-mixin": "24.3.20",
-    "@vaadin/vaadin-usage-statistics": "2.1.2",
+    "@vaadin/vaadin-usage-statistics": "2.1.3",
     "@vaadin/vertical-layout": "24.3.20",
     "@vaadin/virtual-list": "24.3.20",
     "cookieconsent": "3.1.1",


### PR DESCRIPTION
## Description

Upgraded `@vaadin/vaadin-usage-statistics` for 24.3 branch.

## Type of change

- Version bump