### PR TITLE
chore!: remove Polymer and polymer-legacy-adapter

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -21,6 +21,8 @@ export const exposePackages = {
     'lit-element',
     '@lit/reactive-element',
     '@lit-labs/ssr-dom-shim',
+    // TODO: workaround to not include Polymer until it is removed from V25
+    '@polymer/polymer'
   ],
 };
 
@@ -110,4 +112,6 @@ export const autoUpdatePackages = [
   'lit-element',
   '@lit/reactive-element',
   '@lit-labs/ssr-dom-shim',
+  // TODO: workaround to not include Polymer until it is removed from V25
+  '@polymer/polymer'
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "devDependencies": {
         "@lit-labs/ssr-dom-shim": "./src/fake-modules/@lit-labs/ssr-dom-shim",
         "@lit/reactive-element": "./src/fake-modules/@lit/reactive-element",
-        "@polymer/polymer": "3.5.2",
         "@rollup/plugin-node-resolve": "^13.1.3",
         "@rollup/plugin-typescript": "^8.3.0",
         "@rollup/pluginutils": "^4.1.2",
@@ -67,7 +66,6 @@
         "@vaadin/number-field": "24.8.0-alpha18",
         "@vaadin/overlay": "24.8.0-alpha18",
         "@vaadin/password-field": "24.8.0-alpha18",
-        "@vaadin/polymer-legacy-adapter": "24.8.0-alpha18",
         "@vaadin/popover": "24.8.0-alpha18",
         "@vaadin/progress-bar": "24.8.0-alpha18",
         "@vaadin/radio-group": "24.8.0-alpha18",
@@ -104,7 +102,6 @@
       },
       "peerDependencies": {
         "@open-wc/dedupe-mixin": "1.4.0",
-        "@polymer/polymer": "3.5.2",
         "@vaadin/a11y-base": "24.8.0-alpha18",
         "@vaadin/accordion": "24.8.0-alpha18",
         "@vaadin/app-layout": "24.8.0-alpha18",
@@ -154,7 +151,6 @@
         "@vaadin/number-field": "24.8.0-alpha18",
         "@vaadin/overlay": "24.8.0-alpha18",
         "@vaadin/password-field": "24.8.0-alpha18",
-        "@vaadin/polymer-legacy-adapter": "24.8.0-alpha18",
         "@vaadin/popover": "24.8.0-alpha18",
         "@vaadin/progress-bar": "24.8.0-alpha18",
         "@vaadin/radio-group": "24.8.0-alpha18",
@@ -187,9 +183,6 @@
       },
       "peerDependenciesMeta": {
         "@open-wc/dedupe-mixin": {
-          "optional": true
-        },
-        "@polymer/polymer": {
           "optional": true
         },
         "@vaadin/a11y-base": {
@@ -337,9 +330,6 @@
           "optional": true
         },
         "@vaadin/password-field": {
-          "optional": true
-        },
-        "@vaadin/polymer-legacy-adapter": {
           "optional": true
         },
         "@vaadin/popover": {
@@ -1600,17 +1590,6 @@
         "@vaadin/text-field": "24.8.0-alpha18",
         "@vaadin/vaadin-lumo-styles": "24.8.0-alpha18",
         "@vaadin/vaadin-material-styles": "24.8.0-alpha18",
-        "@vaadin/vaadin-themable-mixin": "24.8.0-alpha18",
-        "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/polymer-legacy-adapter": {
-      "version": "24.8.0-alpha18",
-      "resolved": "https://registry.npmjs.org/@vaadin/polymer-legacy-adapter/-/polymer-legacy-adapter-24.8.0-alpha18.tgz",
-      "integrity": "sha512-jCTMFEC2En7g0K1O1d8ON5BgeeuqpO3/5L07dWdJEuVpNKJVWlgQP2eeGsIIIX/OWoRbeLX9fkFqSOOOVwq4Fw==",
-      "dev": true,
-      "dependencies": {
-        "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-themable-mixin": "24.8.0-alpha18",
         "lit": "^3.0.0"
       }
@@ -5726,17 +5705,6 @@
         "@vaadin/text-field": "24.8.0-alpha18",
         "@vaadin/vaadin-lumo-styles": "24.8.0-alpha18",
         "@vaadin/vaadin-material-styles": "24.8.0-alpha18",
-        "@vaadin/vaadin-themable-mixin": "24.8.0-alpha18",
-        "lit": "^3.0.0"
-      }
-    },
-    "@vaadin/polymer-legacy-adapter": {
-      "version": "24.8.0-alpha18",
-      "resolved": "https://registry.npmjs.org/@vaadin/polymer-legacy-adapter/-/polymer-legacy-adapter-24.8.0-alpha18.tgz",
-      "integrity": "sha512-jCTMFEC2En7g0K1O1d8ON5BgeeuqpO3/5L07dWdJEuVpNKJVWlgQP2eeGsIIIX/OWoRbeLX9fkFqSOOOVwq4Fw==",
-      "dev": true,
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-themable-mixin": "24.8.0-alpha18",
         "lit": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "devDependencies": {
     "@lit/reactive-element": "./src/fake-modules/@lit/reactive-element",
     "@lit-labs/ssr-dom-shim": "./src/fake-modules/@lit-labs/ssr-dom-shim",
-    "@polymer/polymer": "3.5.2",
     "@rollup/plugin-node-resolve": "^13.1.3",
     "@rollup/plugin-typescript": "^8.3.0",
     "@rollup/pluginutils": "^4.1.2",
@@ -94,7 +93,6 @@
     "@vaadin/number-field": "24.8.0-alpha18",
     "@vaadin/overlay": "24.8.0-alpha18",
     "@vaadin/password-field": "24.8.0-alpha18",
-    "@vaadin/polymer-legacy-adapter": "24.8.0-alpha18",
     "@vaadin/popover": "24.8.0-alpha18",
     "@vaadin/progress-bar": "24.8.0-alpha18",
     "@vaadin/radio-group": "24.8.0-alpha18",
@@ -132,7 +130,6 @@
   },
   "peerDependencies": {
     "@open-wc/dedupe-mixin": "1.4.0",
-    "@polymer/polymer": "3.5.2",
     "@vaadin/a11y-base": "24.8.0-alpha18",
     "@vaadin/accordion": "24.8.0-alpha18",
     "@vaadin/app-layout": "24.8.0-alpha18",
@@ -182,7 +179,6 @@
     "@vaadin/number-field": "24.8.0-alpha18",
     "@vaadin/overlay": "24.8.0-alpha18",
     "@vaadin/password-field": "24.8.0-alpha18",
-    "@vaadin/polymer-legacy-adapter": "24.8.0-alpha18",
     "@vaadin/popover": "24.8.0-alpha18",
     "@vaadin/progress-bar": "24.8.0-alpha18",
     "@vaadin/radio-group": "24.8.0-alpha18",
@@ -215,9 +211,6 @@
   },
   "peerDependenciesMeta": {
     "@open-wc/dedupe-mixin": {
-      "optional": true
-    },
-    "@polymer/polymer": {
       "optional": true
     },
     "@vaadin/a11y-base": {
@@ -365,9 +358,6 @@
       "optional": true
     },
     "@vaadin/password-field": {
-      "optional": true
-    },
-    "@vaadin/polymer-legacy-adapter": {
       "optional": true
     },
     "@vaadin/popover": {

--- a/src/all-imports.js
+++ b/src/all-imports.js
@@ -53,7 +53,6 @@ import '@vaadin/notification/lit.js';
 import '@vaadin/number-field';
 import '@vaadin/overlay';
 import '@vaadin/password-field';
-import '@vaadin/polymer-legacy-adapter';
 import '@vaadin/popover';
 import '@vaadin/progress-bar';
 import '@vaadin/radio-group';
@@ -98,8 +97,6 @@ import '@vaadin/vaadin-development-mode-detector';
 import '@vaadin/vaadin-usage-statistics';
 /* External dependencies */
 import '@open-wc/dedupe-mixin';
-import '@polymer/polymer';
-// ignore non-resolvable import '@webcomponents/shadycss';
 import 'cookieconsent';
 import 'highcharts';
 import 'ol';

--- a/src/test/bundle-json.test.ts
+++ b/src/test/bundle-json.test.ts
@@ -73,13 +73,6 @@ describe('vaadin-bundle.json', () => {
   });
 
   it('should contain Vaadin dependencies', () => {
-    const polymer = getPackage('@polymer/polymer');
-    expect(polymer.version).to.match(/^3\./);
-    expect(polymer.exposes['.'].exports).to.deep.include({
-      source: '@polymer/polymer/polymer-element.js'
-    });
-    expect(polymer.exposes['./polymer-element.js'].exports).to.include('html', 'PolymerElement');
-
     getPackage('highcharts');
 
     const lit = getPackage('lit');

--- a/src/test/bundle.test.ts
+++ b/src/test/bundle.test.ts
@@ -43,8 +43,6 @@ describe('vaadin.js', () => {
     });
 
     it('should contain Vaadin component dependencies', async () => {
-      expect(await get('./node_modules/@polymer/polymer')).to.be.instanceOf(Function);
-      expect(await get('./node_modules/@polymer/polymer/polymer-element.js')).to.be.instanceOf(Function);
       expect(await get('./node_modules/highcharts/es-modules/Core/Chart/Chart.js')).to.be.instanceOf(Function);
     });
 


### PR DESCRIPTION
## Description

I had to use the same approach for excluding Polymer for now as the one we use for Lit dependencies.
Once we actually release 25.0.0-alpha1 in web components, TODOs can be hopefully removed.

## Type of change

- Breaking change