### PR TITLE
chore: fix test to not rely on internal file names

### DIFF
--- a/src/test/bundle-json.test.ts
+++ b/src/test/bundle-json.test.ts
@@ -48,12 +48,6 @@ describe('vaadin-bundle.json', () => {
           }
         ]
       },
-      './src/vaadin-button-base.js': {
-        'exports': [
-           'buttonStyles',
-           'buttonTemplate',
-         ]
-      },
       './src/vaadin-button-mixin.js': {
         exports: ['ButtonMixin']
       },

--- a/src/test/bundle-json.test.ts
+++ b/src/test/bundle-json.test.ts
@@ -33,7 +33,7 @@ describe('vaadin-bundle.json', () => {
   it('should contain Vaadin components', () => {
     const button = getPackage('@vaadin/button');
     expect(button.version).to.equal(bundleVersion);
-    expect(button.exposes).to.deep.equal({
+    expect(button.exposes).to.deep.include({
       '.': {
         exports: [
           {


### PR DESCRIPTION
## Description

The file name was changed, tests should not rely on it as it's an implementation detail.

## Type of change

- Test