### PR TITLE
chore: remove no longer needed Polymer workaround

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -21,8 +21,6 @@ export const exposePackages = {
     'lit-element',
     '@lit/reactive-element',
     '@lit-labs/ssr-dom-shim',
-    // TODO: workaround to not include Polymer until it is removed from V25
-    '@polymer/polymer'
   ],
 };
 
@@ -111,6 +109,4 @@ export const autoUpdatePackages = [
   'lit-element',
   '@lit/reactive-element',
   '@lit-labs/ssr-dom-shim',
-  // TODO: workaround to not include Polymer until it is removed from V25
-  '@polymer/polymer'
 ];


### PR DESCRIPTION
## Description

Removing TODOs added in https://github.com/vaadin/bundles/pull/151. Verified that Polymer doesn't get installed / imported.

## Type of change

- Internal change