### PR TITLE
chore: fix test to not rely on internal file names (#153) (CP: 24.8)

### DIFF
--- a/src/test/bundle-json.test.ts
+++ b/src/test/bundle-json.test.ts
@@ -33,7 +33,7 @@ describe('vaadin-bundle.json', () => {
   it('should contain Vaadin components', () => {
     const button = getPackage('@vaadin/button');
     expect(button.version).to.equal(bundleVersion);
-    expect(button.exposes).to.deep.equal({
+    expect(button.exposes).to.deep.include({
       '.': {
         exports: [
           {
@@ -47,12 +47,6 @@ describe('vaadin-bundle.json', () => {
             source: '@vaadin/button/src/vaadin-button.js'
           }
         ]
-      },
-      './src/vaadin-button-base.js': {
-        'exports': [
-           'buttonStyles',
-           'buttonTemplate',
-         ]
       },
       './src/vaadin-button-mixin.js': {
         exports: ['ButtonMixin']


### PR DESCRIPTION
## Description

Cherry-pick of the test fix to 24.8 branch to avoid failures with the next 24.8 WC alpha.

## Type of change

- Cherry-pick