### PR TITLE
chore: add style-observer, fix webpack conditionNames

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -179,7 +179,8 @@
         "marked": "15.0.11",
         "ol": "6.13.0",
         "quickselect": "2.0.0",
-        "rbush": "3.0.1"
+        "rbush": "3.0.1",
+        "style-observer": "0.0.8"
       },
       "peerDependenciesMeta": {
         "@open-wc/dedupe-mixin": {
@@ -417,6 +418,9 @@
           "optional": true
         },
         "rbush": {
+          "optional": true
+        },
+        "style-observer": {
           "optional": true
         }
       }
@@ -3899,7 +3903,7 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/style-observer/-/style-observer-0.0.8.tgz",
       "integrity": "sha512-UaIPn33Sx4BJ+goia51Q++VFWoplWK1995VdxQYzwwbFa+FUNLKlG+aiIdG2Vw7VyzIUBi8tqu8mTyg0Ppu6Yg==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -3909,7 +3913,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/leaverou"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "8.1.1",
@@ -7356,7 +7361,7 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/style-observer/-/style-observer-0.0.8.tgz",
       "integrity": "sha512-UaIPn33Sx4BJ+goia51Q++VFWoplWK1995VdxQYzwwbFa+FUNLKlG+aiIdG2Vw7VyzIUBi8tqu8mTyg0Ppu6Yg==",
-      "dev": true
+      "devOptional": true
     },
     "supports-color": {
       "version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -207,7 +207,8 @@
     "marked": "15.0.11",
     "ol": "6.13.0",
     "quickselect": "2.0.0",
-    "rbush": "3.0.1"
+    "rbush": "3.0.1",
+    "style-observer": "0.0.8"
   },
   "peerDependenciesMeta": {
     "@open-wc/dedupe-mixin": {
@@ -445,6 +446,9 @@
       "optional": true
     },
     "rbush": {
+      "optional": true
+    },
+    "style-observer": {
       "optional": true
     }
   }

--- a/src/all-imports.js
+++ b/src/all-imports.js
@@ -104,6 +104,7 @@ import 'rbush';
 import 'quickselect';
 import 'marked';
 import 'dompurify';
+import 'style-observer';
 // ignore bundle internal import 'lit-html';
 // ignore bundle internal import 'lit-element';
 // ignore bundle internal import '@lit/reactive-element';

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -2,7 +2,7 @@ import { readFile } from 'fs/promises';
 import * as path from 'path';
 import { default as ModuleFederationPlugin } from 'webpack/lib/container/ModuleFederationPlugin.js';
 // @ts-ignore TS2691 ts-node/esm loader fails when missing extension here
-import { modulesDirectory } from './build.config.ts'; 
+import { modulesDirectory } from './build.config.ts';
 import { BundleJson } from './src/lib/bundle-json';
 
 const bundleJson: BundleJson = JSON.parse(await readFile('vaadin-bundle.json', { encoding: 'utf8' }));
@@ -22,9 +22,7 @@ export default {
   },
   resolve: {
     symlinks: false,
-    conditionNames: [
-      'development'
-    ]
+    conditionNames: ['development', 'import']
   },
   module: {
     rules: [


### PR DESCRIPTION
## Description

- Added `style-observer` (dependency of `@vaadin/vaadin-themable-mixin`)
- Fixed `conditionNames` in webpack config to not fail on this package

```
ERROR in ./src/all-imports.js 107:0-24
Module not found: Error: Package path . is not exported from package /Users/serhii/vaadin/bundles/node_modules/style-observer (see exports field in /Users/serhii/vaadin/bundles/node_modules/style-observer/package.json)
```

## Type of change

- Internal change