### PR TITLE
chore: remove no longer used style-observer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -179,8 +179,7 @@
         "marked": "15.0.12",
         "ol": "6.13.0",
         "quickselect": "2.0.0",
-        "rbush": "3.0.1",
-        "style-observer": "0.0.8"
+        "rbush": "3.0.1"
       },
       "peerDependenciesMeta": {
         "@open-wc/dedupe-mixin": {
@@ -418,9 +417,6 @@
           "optional": true
         },
         "rbush": {
-          "optional": true
-        },
-        "style-observer": {
           "optional": true
         }
       }
@@ -3900,24 +3896,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/style-observer": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/style-observer/-/style-observer-0.0.8.tgz",
-      "integrity": "sha512-UaIPn33Sx4BJ+goia51Q++VFWoplWK1995VdxQYzwwbFa+FUNLKlG+aiIdG2Vw7VyzIUBi8tqu8mTyg0Ppu6Yg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/LeaVerou"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/leaverou"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -7359,13 +7337,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
-    },
-    "style-observer": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/style-observer/-/style-observer-0.0.8.tgz",
-      "integrity": "sha512-UaIPn33Sx4BJ+goia51Q++VFWoplWK1995VdxQYzwwbFa+FUNLKlG+aiIdG2Vw7VyzIUBi8tqu8mTyg0Ppu6Yg==",
-      "optional": true,
-      "peer": true
     },
     "supports-color": {
       "version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -207,8 +207,7 @@
     "marked": "15.0.12",
     "ol": "6.13.0",
     "quickselect": "2.0.0",
-    "rbush": "3.0.1",
-    "style-observer": "0.0.8"
+    "rbush": "3.0.1"
   },
   "peerDependenciesMeta": {
     "@open-wc/dedupe-mixin": {
@@ -446,9 +445,6 @@
       "optional": true
     },
     "rbush": {
-      "optional": true
-    },
-    "style-observer": {
       "optional": true
     }
   }

--- a/src/all-imports.js
+++ b/src/all-imports.js
@@ -104,7 +104,6 @@ import 'rbush';
 import 'quickselect';
 import 'marked';
 import 'dompurify';
-import 'style-observer';
 // ignore bundle internal import 'lit-html';
 // ignore bundle internal import 'lit-element';
 // ignore bundle internal import '@lit/reactive-element';

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -22,7 +22,7 @@ export default {
   },
   resolve: {
     symlinks: false,
-    conditionNames: ['development', 'import']
+    conditionNames: ['development']
   },
   module: {
     rules: [


### PR DESCRIPTION
## Description

Usage of `style-observer` has been removed since https://github.com/vaadin/web-components/pull/9337. Let's remove it.

## Type of change

- Internal change