### PR TITLE
refactor: update to only include Lumo iconset by default

### DIFF
--- a/src/all-imports.js
+++ b/src/all-imports.js
@@ -85,7 +85,7 @@ import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
 import '@vaadin/map';
 import '@vaadin/rich-text-editor';
 /* Theme */
-import '@vaadin/vaadin-lumo-styles';
+import '@vaadin/vaadin-lumo-styles/icons.js';
 /* Internal dependencies */
 import '@vaadin/component-base';
 import '@vaadin/a11y-base';

--- a/src/test/bundle-json.test.ts
+++ b/src/test/bundle-json.test.ts
@@ -87,7 +87,11 @@ describe('vaadin-bundle.json', () => {
       .filter((line) => line.startsWith('import '))
       .map((importLine) => /^import '([^']*)';$/.exec(importLine)[1]) as string[];
     const missingPackageNames = new Set(packageNames.sort());
-    allImports.forEach((source) => missingPackageNames.delete(source));
+    allImports.forEach((source) => {
+      // Get the actual npm package name
+      const name = source.split('/').slice(0,2).join('/');
+      missingPackageNames.delete(name);
+    });
     if (missingPackageNames.size > 0) {
       expect.fail(`Detected missing package(s) in src/all-imports.js:
 


### PR DESCRIPTION
## Description

This file should be the only needed after switching Lumo to CSS: https://github.com/vaadin/flow-components/pull/7668

## Type of change

- Breaking change

## Note

The `all-imports.js` is still created as a separate chunk but is not in the default `vaadin.js` bundle anymore:

```
asset vendors-node_modules_vaadin_vaadin-lumo-styles_all-imports_js.js 122 KiB [compared for emit] [javascript module] (id hint: vendors) 1 related asset
```