### PR TITLE
refactor!: remove cookie consent in v25

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -45,7 +45,6 @@ export const vaadinWebComponentPackages = [
   '@vaadin/component-base',
   '@vaadin/confirm-dialog',
   '@vaadin/context-menu',
-  '@vaadin/cookie-consent',
   '@vaadin/crud',
   '@vaadin/custom-field',
   '@vaadin/dashboard',

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "@vaadin/component-base": "25.0.0-alpha15",
         "@vaadin/confirm-dialog": "25.0.0-alpha15",
         "@vaadin/context-menu": "25.0.0-alpha15",
-        "@vaadin/cookie-consent": "25.0.0-alpha15",
         "@vaadin/crud": "25.0.0-alpha15",
         "@vaadin/custom-field": "25.0.0-alpha15",
         "@vaadin/dashboard": "25.0.0-alpha15",
@@ -88,7 +87,6 @@
         "@vaadin/vertical-layout": "25.0.0-alpha15",
         "@vaadin/virtual-list": "25.0.0-alpha15",
         "chai": "^4.3.4",
-        "cookieconsent": "3.1.1",
         "lit": "3.3.1",
         "lit-element": "./src/fake-modules/lit-element",
         "lit-html": "./src/fake-modules/lit-html",
@@ -117,7 +115,6 @@
         "@vaadin/component-base": "25.0.0-alpha15",
         "@vaadin/confirm-dialog": "25.0.0-alpha15",
         "@vaadin/context-menu": "25.0.0-alpha15",
-        "@vaadin/cookie-consent": "25.0.0-alpha15",
         "@vaadin/crud": "25.0.0-alpha15",
         "@vaadin/custom-field": "25.0.0-alpha15",
         "@vaadin/dashboard": "25.0.0-alpha15",
@@ -172,7 +169,6 @@
         "@vaadin/vaadin-usage-statistics": "2.1.3",
         "@vaadin/vertical-layout": "25.0.0-alpha15",
         "@vaadin/virtual-list": "25.0.0-alpha15",
-        "cookieconsent": "3.1.1",
         "dompurify": "3.2.6",
         "highcharts": "9.2.2",
         "lit": "3.3.1",
@@ -228,9 +224,6 @@
           "optional": true
         },
         "@vaadin/context-menu": {
-          "optional": true
-        },
-        "@vaadin/cookie-consent": {
           "optional": true
         },
         "@vaadin/crud": {
@@ -393,9 +386,6 @@
           "optional": true
         },
         "@vaadin/virtual-list": {
-          "optional": true
-        },
-        "cookieconsent": {
           "optional": true
         },
         "dompurify": {
@@ -946,18 +936,6 @@
         "@vaadin/lit-renderer": "25.0.0-alpha15",
         "@vaadin/overlay": "25.0.0-alpha15",
         "@vaadin/vaadin-themable-mixin": "25.0.0-alpha15",
-        "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/cookie-consent": {
-      "version": "25.0.0-alpha15",
-      "resolved": "https://registry.npmjs.org/@vaadin/cookie-consent/-/cookie-consent-25.0.0-alpha15.tgz",
-      "integrity": "sha512-w8x5bBMfCavbFV7nAnIWinazzoLuEgeKdCIHZz+KOS4acvrRxWBSOnY4tNyXUE4ASvscwxbvYTXiakCkYqpEhA==",
-      "dev": true,
-      "dependencies": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@vaadin/component-base": "25.0.0-alpha15",
-        "cookieconsent": "^3.0.6",
         "lit": "^3.0.0"
       }
     },
@@ -2291,12 +2269,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
-    },
-    "node_modules/cookieconsent": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/cookieconsent/-/cookieconsent-3.1.1.tgz",
-      "integrity": "sha512-v8JWLJcI7Zs9NWrs8hiVldVtm3EBF70TJI231vxn6YToBGj0c9dvdnYwltydkAnrbBMOM/qX1xLFrnTfm5wTag==",
       "dev": true
     },
     "node_modules/create-require": {
@@ -4743,18 +4715,6 @@
         "lit": "^3.0.0"
       }
     },
-    "@vaadin/cookie-consent": {
-      "version": "25.0.0-alpha15",
-      "resolved": "https://registry.npmjs.org/@vaadin/cookie-consent/-/cookie-consent-25.0.0-alpha15.tgz",
-      "integrity": "sha512-w8x5bBMfCavbFV7nAnIWinazzoLuEgeKdCIHZz+KOS4acvrRxWBSOnY4tNyXUE4ASvscwxbvYTXiakCkYqpEhA==",
-      "dev": true,
-      "requires": {
-        "@open-wc/dedupe-mixin": "^1.3.0",
-        "@vaadin/component-base": "25.0.0-alpha15",
-        "cookieconsent": "^3.0.6",
-        "lit": "^3.0.0"
-      }
-    },
     "@vaadin/crud": {
       "version": "25.0.0-alpha15",
       "resolved": "https://registry.npmjs.org/@vaadin/crud/-/crud-25.0.0-alpha15.tgz",
@@ -5956,12 +5916,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
-    },
-    "cookieconsent": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/cookieconsent/-/cookieconsent-3.1.1.tgz",
-      "integrity": "sha512-v8JWLJcI7Zs9NWrs8hiVldVtm3EBF70TJI231vxn6YToBGj0c9dvdnYwltydkAnrbBMOM/qX1xLFrnTfm5wTag==",
       "dev": true
     },
     "create-require": {

--- a/package.json
+++ b/package.json
@@ -37,14 +37,15 @@
   },
   "homepage": "https://github.com/vaadin/platform#readme",
   "devDependencies": {
-    "@lit/reactive-element": "./src/fake-modules/@lit/reactive-element",
     "@lit-labs/ssr-dom-shim": "./src/fake-modules/@lit-labs/ssr-dom-shim",
+    "@lit/reactive-element": "./src/fake-modules/@lit/reactive-element",
     "@rollup/plugin-node-resolve": "^13.1.3",
     "@rollup/plugin-typescript": "^8.3.0",
     "@rollup/pluginutils": "^4.1.2",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^9.1.0",
     "@types/node": "^17.0.19",
+    "@vaadin/a11y-base": "25.0.0-alpha15",
     "@vaadin/accordion": "25.0.0-alpha15",
     "@vaadin/app-layout": "25.0.0-alpha15",
     "@vaadin/avatar": "25.0.0-alpha15",
@@ -59,7 +60,6 @@
     "@vaadin/component-base": "25.0.0-alpha15",
     "@vaadin/confirm-dialog": "25.0.0-alpha15",
     "@vaadin/context-menu": "25.0.0-alpha15",
-    "@vaadin/cookie-consent": "25.0.0-alpha15",
     "@vaadin/crud": "25.0.0-alpha15",
     "@vaadin/custom-field": "25.0.0-alpha15",
     "@vaadin/dashboard": "25.0.0-alpha15",
@@ -115,7 +115,6 @@
     "@vaadin/vertical-layout": "25.0.0-alpha15",
     "@vaadin/virtual-list": "25.0.0-alpha15",
     "chai": "^4.3.4",
-    "cookieconsent": "3.1.1",
     "lit": "3.3.1",
     "lit-element": "./src/fake-modules/lit-element",
     "lit-html": "./src/fake-modules/lit-html",
@@ -125,8 +124,7 @@
     "tslib": "*",
     "typescript": "^4.5.5",
     "webpack": "^5.68.0",
-    "webpack-cli": "^4.9.2",
-    "@vaadin/a11y-base": "25.0.0-alpha15"
+    "webpack-cli": "^4.9.2"
   },
   "peerDependencies": {
     "@open-wc/dedupe-mixin": "1.4.0",
@@ -145,7 +143,6 @@
     "@vaadin/component-base": "25.0.0-alpha15",
     "@vaadin/confirm-dialog": "25.0.0-alpha15",
     "@vaadin/context-menu": "25.0.0-alpha15",
-    "@vaadin/cookie-consent": "25.0.0-alpha15",
     "@vaadin/crud": "25.0.0-alpha15",
     "@vaadin/custom-field": "25.0.0-alpha15",
     "@vaadin/dashboard": "25.0.0-alpha15",
@@ -200,7 +197,6 @@
     "@vaadin/vaadin-usage-statistics": "2.1.3",
     "@vaadin/vertical-layout": "25.0.0-alpha15",
     "@vaadin/virtual-list": "25.0.0-alpha15",
-    "cookieconsent": "3.1.1",
     "dompurify": "3.2.6",
     "highcharts": "9.2.2",
     "lit": "3.3.1",
@@ -256,9 +252,6 @@
       "optional": true
     },
     "@vaadin/context-menu": {
-      "optional": true
-    },
-    "@vaadin/cookie-consent": {
       "optional": true
     },
     "@vaadin/crud": {
@@ -421,9 +414,6 @@
       "optional": true
     },
     "@vaadin/virtual-list": {
-      "optional": true
-    },
-    "cookieconsent": {
       "optional": true
     },
     "dompurify": {

--- a/src/all-imports.js
+++ b/src/all-imports.js
@@ -76,7 +76,6 @@ import '@vaadin/virtual-list/lit.js';
 import '@vaadin/board';
 import '@vaadin/charts';
 import '@vaadin/confirm-dialog';
-import '@vaadin/cookie-consent';
 import '@vaadin/crud';
 import '@vaadin/dashboard';
 import '@vaadin/grid-pro';
@@ -97,7 +96,6 @@ import '@vaadin/vaadin-development-mode-detector';
 import '@vaadin/vaadin-usage-statistics';
 /* External dependencies */
 import '@open-wc/dedupe-mixin';
-import 'cookieconsent';
 import 'highcharts';
 import 'ol';
 import 'rbush';


### PR DESCRIPTION
## Description

Remove the deprecated `<vaadin-cookie-consent>` component from bundles in v25.

Part of https://github.com/vaadin/web-components/issues/9791

## Type of change

- Breaking change