### PR TITLE
fix: specify charts version in version script

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -99,6 +99,10 @@ export const vaadinWebComponentPackages = [
   '@vaadin/vertical-layout',
 ];
 
+export const dependencyPackages = {
+  highcharts: '12.2.0'
+};
+
 /**
  * The listed packages are automatically updated to the newest matching
  * version for every new version of bundles. See the `npm version` script.

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -5,7 +5,7 @@ import { env } from 'process';
 import { promisify } from 'util';
 import * as child_process from 'child_process';
 import.meta.resolve
-import { autoUpdatePackages, modulesDirectory, vaadinWebComponentPackages } from '../build.config.js';
+import { autoUpdatePackages, dependencyPackages, modulesDirectory, vaadinWebComponentPackages } from '../build.config.js';
 import { Module } from 'module';
 
 async function exec(cmd: string): Promise<void> {
@@ -31,6 +31,10 @@ for (const p of vaadinWebComponentPackages) {
   packageJson.devDependencies[p] = version;
   packageJson.peerDependencies[p] = version;
 }
+Object.entries(dependencyPackages).forEach(([p,v]) => {
+  packageJson.devDependencies[p] = v;
+  packageJson.peerDependencies[p] = v;
+});
 await fsPromises.writeFile(
   'package.json',
   JSON.stringify(packageJson, undefined, 2),

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -32,7 +32,6 @@ for (const p of vaadinWebComponentPackages) {
   packageJson.peerDependencies[p] = version;
 }
 Object.entries(dependencyPackages).forEach(([p,v]) => {
-  packageJson.devDependencies[p] = v;
   packageJson.peerDependencies[p] = v;
 });
 await fsPromises.writeFile(


### PR DESCRIPTION
## Description

This should make `npm version` pick up correct version of `highcharts` for next WC alpha.

## Type of change

- Bugfix