### PR TITLE
chore: bump dompurify peer dependency to 3.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -169,7 +169,7 @@
         "@vaadin/vaadin-usage-statistics": "2.1.3",
         "@vaadin/vertical-layout": "25.0.0-alpha19",
         "@vaadin/virtual-list": "25.0.0-alpha19",
-        "dompurify": "3.2.6",
+        "dompurify": "3.2.7",
         "highcharts": "12.2.0",
         "lit": "3.3.1",
         "marked": "15.0.12",
@@ -2359,9 +2359,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "devOptional": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -5984,9 +5984,9 @@
       "dev": true
     },
     "dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "devOptional": true,
       "requires": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "@vaadin/vaadin-usage-statistics": "2.1.3",
     "@vaadin/vertical-layout": "25.0.0-alpha19",
     "@vaadin/virtual-list": "25.0.0-alpha19",
-    "dompurify": "3.2.6",
+    "dompurify": "3.2.7",
     "highcharts": "12.2.0",
     "lit": "3.3.1",
     "marked": "15.0.12",


### PR DESCRIPTION
## Description

The new version of `dompurify` used by `vaadin-markdown` is out, let's update bundles so it doesn't warn:

<img width="780" height="386" alt="image" src="https://github.com/user-attachments/assets/10db2edf-7318-431a-b48d-28686ffbc453" />

Note: didn't add it to `dependencyPackages` for now to make cherry-picking possible.

## Type of change

- Internal change