### PR TITLE
chore: bump dompurify peer dependency to 3.2.7 (CP: 24.9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -177,7 +177,7 @@
         "@vaadin/vertical-layout": "24.9.0",
         "@vaadin/virtual-list": "24.9.0",
         "cookieconsent": "3.1.1",
-        "dompurify": "3.2.6",
+        "dompurify": "3.2.7",
         "highcharts": "9.2.2",
         "lit": "3.3.0",
         "marked": "15.0.12",
@@ -2652,9 +2652,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "devOptional": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -6626,9 +6626,9 @@
       "dev": true
     },
     "dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "devOptional": true,
       "requires": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "@vaadin/vertical-layout": "24.9.0",
     "@vaadin/virtual-list": "24.9.0",
     "cookieconsent": "3.1.1",
-    "dompurify": "3.2.6",
+    "dompurify": "3.2.7",
     "highcharts": "9.2.2",
     "lit": "3.3.0",
     "marked": "15.0.12",


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/vaadin/bundles/pull/169 to `24.9` branch.

## Type of change

- Cherry-pick