### PR TITLE
chore: add 24.9 branch to validation workflow

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - '24.9'
       - '24.8'
       - '24.0'
       - '23.0'
@@ -16,6 +17,7 @@ on:
   pull_request_target:
     branches:
       - 'main'
+      - '24.9'
       - '24.8'
       - '24.0'
       - '23.0'


### PR DESCRIPTION
## Description

This is needed to enable validation builds on `24.9` branch.

## Type of change

- Internal change